### PR TITLE
cordova-android 11 compatibility

### DIFF
--- a/hooks/android/configureProjectLevelDependency.js
+++ b/hooks/android/configureProjectLevelDependency.js
@@ -4,7 +4,7 @@ const path = require('path')
 function addProjectLevelDependency(platformRoot) {
   return new Promise((resolve, reject) => {
     try {
-      const lib = 'com.google.gms:google-services:4.3.10'
+      const lib = 'com.google.gms:google-services:4.3.14'
       const dependency = `classpath '${lib}'`
     
       const projectBuildFile = path.join(platformRoot, 'build.gradle')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-push-notifications",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Push Notification for iOS (Swift) and Android (Kotlin)",
   "cordova": {
     "id": "cordova-plugin-push-notifications",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-push-notifications" version="1.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-push-notifications" version="1.1.6" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>cordova-plugin-push-notifications</name>
     <js-module name="PushNotification" src="www/PushNotification.js">
         <clobbers target="pushNotification" />
     </js-module>
     <engines>
         <engine name="cordova" version=">=9.0.0"/>
-        <engine name="cordova-android" version=">=9.0.0"/>
+        <engine name="cordova-android" version=">=11.0.0"/>
         <engine name="cordova-ios" version=">=5.0.0"/>
     </engines>
     <platform name="ios">
@@ -25,7 +25,7 @@
             <preference name="GradlePluginKotlinEnabled" value="true" />
             <preference name="GradlePluginGoogleServicesEnabled" value="true" />
             <preference name="GradlePluginKotlinCodeStyle" value="official" />
-            <preference name="GradlePluginKotlinVersion" value="1.3.50" />
+            <preference name="GradlePluginKotlinVersion" value="1.6.20" />
 
             <feature name="PushNotification">
                 <param name="android-package" value="notifications.Notifications" />
@@ -45,7 +45,7 @@
         <source-file src="src/android/MyFirebaseMessagingService.kt" target-dir="src/main/kotlin/notifications" />
         <source-file src="src/android/build-extras.gradle" target-dir="."/>
 
-        <framework src="com.google.gms:google-services:4.3.10" />
+        <framework src="com.google.gms:google-services:4.3.14" />
         <framework src="com.google.firebase:firebase-messaging:20.0.1" />
 
         <hook src="hooks/android/configureProjectLevelDependency.js" type="before_build" />


### PR DESCRIPTION
Since Aug 2022 Google requires targetApi>=31, which is only availably with cordova-android>=11.

This commit updates library references to run with those versions.